### PR TITLE
Fix for empty id='' tag on <img> if ppgen user omits id= on .il command

### DIFF
--- a/ppgen.py
+++ b/ppgen.py
@@ -3005,6 +3005,7 @@ class Pph(Book):
       iid = ""
       if "id=" in s:
         s, iid = self.get_id("id",s)
+        iid = "id='{}' ".format(iid)  # fix for missing id= problem
       ia["id"] = iid
 
       # alt text for image
@@ -3119,12 +3120,12 @@ class Pph(Book):
     # create replacement stanza for illustration
     u = []
 
-    if ia["align"] == "c":
-      u.append("<div id='{}' class='figcenter {}'>".format(ia["id"], idn))
+    if ia["align"] == "c":  # with fix for missing id= problem
+      u.append("<div {} class='figcenter {}'>".format(ia["id"], idn))
     if ia["align"] == "l":
-      u.append("<div id='{}' class='figleft {}'>".format(ia["id"], idn))
+      u.append("<div {} class='figleft {}'>".format(ia["id"], idn))
     if ia["align"] == "r":
-      u.append("<div id='{}' class='figright {}'>".format(ia["id"], idn))
+      u.append("<div {} class='figright {}'>".format(ia["id"], idn))
 
     # 16-Apr-2014: placed link in div
     if ia["link"] != "": # link to larger image specified in markup


### PR DESCRIPTION
This should fix the problem that Sonya reported in the forum,
  http://www.pgdp.net/phpBB2/viewtopic.php?p=992576#992576
