### PR TITLE
Fix issue with multiline captions not being wrapped in text versions

### DIFF
--- a/ppgen.py
+++ b/ppgen.py
@@ -1340,7 +1340,9 @@ class Ppt(Book):
           self.eb += t
           self.cl += 1
           while not (self.wb[self.cl]).startswith(".ca"):
-            self.eb.append(self.wb[self.cl])
+            s = self.wb[self.cl]
+            t = self.wrap(s, 0, self.regLL, 0)
+            self.eb += t
             self.cl += 1
           self.eb[-1] += "]"
           self.cl += 1 # the closing .ca-


### PR DESCRIPTION
While working on my current PPing project I ran into an issue where long lines within a multiline caption were not being wrapped in the text versions. I'm not sure if this behavior was intentional, but I can't think of a case where wrapping here would be an issue. This change adds line wrap to multiline captions. 

Below is the ppgen code that illustrates the problem:

```
.il id=i141 fn=i_141.jpg w=62% alt='' 
.ca
<i>Fig. 14.</i>

<sc>Plant of Crosswort</sc> (<i><lang="la">Galium cruciatum</i>), with the larva and perfect insect of the <sc>Bloody-Nosed Beetle</sc> (<i><lang="la">Timarcha tenebricosa</lang></i>).
.ca-
```
