### PR TITLE
Feature inline image

### DIFF
--- a/ppgen.py
+++ b/ppgen.py
@@ -234,6 +234,8 @@ class Book(object):
       self.doSpace()
     elif ".fs" == dotcmd:
       self.doFontSize()
+    elif ".ic" == dotcmd: # inline container
+      self.doIc()
     elif ".il" == dotcmd:
       self.doIllo()
     elif ".in" == dotcmd:
@@ -1320,6 +1322,12 @@ class Ppt(Book):
   # change font size for following paragraphs
   # no effect in text
   def doFontSize(self):
+    del self.wb[self.cl]
+
+  # .ic
+  # Container for inline-block elements
+  # no effect in text
+  def doIc(self):
     del self.wb[self.cl]
 
   # .il illustrations (text)
@@ -2907,6 +2915,19 @@ class Pph(Book):
     if ".fs" in self.wb[self.cl]:
       self.warn("font-size directive error: {}".format(self.wb[self.cl]))
     del self.wb[self.cl]
+
+  # .ic
+  # Container for inline-block elements
+  def doIc(self):
+    if ".ic" == self.wb[self.cl]: # opening tag
+      self.css.addcss("[620] div.inlinecontainer { clear: both; margin: 0em auto; text-align: center; max-width: 100%; }")
+      self.wb[self.cl] = "<div class='inlinecontainer'>"
+      self.cl += 1
+    elif ".ic-" == self.wb[self.cl]: # closing tag
+      self.wb[self.cl] = "</div>"
+      self.cl += 1
+    else:
+      self.fatal("inline container directive error: {}".format(self.wb[self.cl]))
 
   # .il illustrations
   # .il id=i01 fn=illus-fpc.jpg w=332 alt=illus-fpcf.jpg


### PR DESCRIPTION
For my current project I needed the ability to display illustrations side by side so I added this feature to ppgen. The changes consist of a new option for the .il align parameter 'i' (inline), and a new directive .ic (inline container). This is a big change; I'm sure you have thought about this problem more than I have and just wanted to suggest a possible solution. Consider this pull request as an opening for discussion.

Here is an example of how to display two images side by side:

```
.ic
.il id=i096a fn=i_096a.jpg w=30% alt='' align='i' cj='c'
.ca <i>Fig. 7.</i>
.il id=i096b fn=i_096b.jpg w=30% alt='' align='i' cj='c'
.ca <i>Fig. 8.</i>
.ic-
```

HTML result from above code:

```
<div class='inlinecontainer'>
  <div id='i096a'  class='figinline id009'>
    <img src='images/i_096a.jpg' alt='' class='ig009' />
    <div class='ic009'>
      <p><i>Fig. 7.</i></p>
    </div>
  </div>
  <div id='i096b'  class='figinline id010'>
    <img src='images/i_096b.jpg' alt='' class='ig010' />
    <div class='ic010'>
      <p><i>Fig. 8.</i></p>
    </div>
  </div>
</div>
```

CSS result from above code:

```
div.inlinecontainer { clear: both; margin: 0em auto; text-align: center; max-width: 100%; }
.figinline { display:inline-block; vertical-align:middle; max-width:100%; margin:1em; text-align: center;}
div.figinline p { text-align:center; text-indent:0; }
```

Originally I had an override in place to use display:block rather than display:inline-block for eBook readers 

```
@media handheld { .figinline { display:block; }}
```

But found that inline-block was handled properly on all devices I tested against and the override was not needed.

It's possible in the future that the .ic directive could be used for inline display of other block elements besides img (like a multi column layout?)
