### PR TITLE
Add cp parameter to .il statement (caption placement)

### DIFF
--- a/ppgen.py
+++ b/ppgen.py
@@ -3019,6 +3019,12 @@ class Pph(Book):
         my_cj = cj[0]
       ia["cj"] = my_cj
 
+      # caption placement; (t)op, (b)ottom
+      cp = "b"
+      if "cp=" in s:
+        s, cp = self.get_id("cp",s)
+      ia["cp"] = cp
+      
       # user-requested id
       iid = ""
       if "id=" in s:
@@ -3165,7 +3171,8 @@ class Pph(Book):
 
     # is the .il line followed by a caption line?
     if caption_present:
-      u.append("<div class='{}'>".format(icn))
+      c = []
+      c.append("<div class='{}'>".format(icn))
       if self.wb[self.cl+1] == ".ca": # multiline
         rep += 1
         j = 2
@@ -3181,8 +3188,17 @@ class Pph(Book):
       else: # single line
         caption = self.wb[self.cl+1][4:]
         rep += 1
-      u.append("<p>{}</p>".format(caption))
-      u.append("</div>")
+      c.append("<p>{}</p>".format(caption))
+      c.append("</div>")
+      
+      # insert caption block into illustration div
+      if ia["cp"] == 'b': # insert after image (bottom)
+        u = u + c
+      elif ia["cp"] == 't': # insert before image (top)
+        u[1:1] = c
+      else:
+        self.fatal("invalid cp parameter: cp=\"{}\"".format(ia["cp"]))
+      
     u.append("</div>") # the entire illustration div
 
     # replace with completed HTML


### PR DESCRIPTION
Hi Roger,

In a recent project I wanted the ability to place an illustrations caption above it rather than below. This change allows that by adding a new flag to the .il statement, cp (caption placement or position). There are two possible values for this parameter (t)op and (b)ottom. If the parameter is not supplied it defaults to bottom (current behavior). 

In the future, I was thinking about adding an additional possible value (s)plit that would allow for captions to be placed above and below an illustration like

```
                   Fig 1.
+----------------------------------------+
|                                        |
|                                        |
|                                        |
|                                        |
+----------------------------------------+
          This is an example of a
               split caption.
```
