### PR TITLE
Develop

### DIFF
--- a/ppgen.py
+++ b/ppgen.py
@@ -2377,17 +2377,24 @@ class Pph(Book):
     # <lang> tags processed in HTML.
     # <lang="fr">merci</lang>
     # <span lang="fr xml:lang="fr">merci</span>
-    for i in range(len(self.wb)):
-      # m = re.search(r"<lang=[\"']?([^>]+)[\"']?>",self.wb[i])
-      m = re.search(r"<lang=[\"']?([^\"'>]+)[\"']?>",self.wb[i])
-      while m:
-        langspec = m.group(1)
-        self.wb[i] = re.sub(m.group(0), "ᒪ'{}'".format(langspec), self.wb[i], 1)
-        # self.wb[i] = re.sub(m.group(0), "<span LANG=\"{0}\" xml:LANG=\"{0}\">".format(langspec), self.wb[i], 1)
+    i = 0
+    while i < len(self.wb):
+      if self.wb[i] == ".li":         # ignore literal blocks
+        while i < len(self.wb) and self.wb[i] != ".li-":
+          i += 1
+        i += 1  # skip over .li- command
+      else:
+        # m = re.search(r"<lang=[\"']?([^>]+)[\"']?>",self.wb[i])
         m = re.search(r"<lang=[\"']?([^\"'>]+)[\"']?>",self.wb[i])
-      if "lang=" in self.wb[i]:
-        self.fatal("incorrect lang markup: {}".format(self.wb[i]))  # TODO: protect if inside .li
-      self.wb[i] = re.sub(r"<\/lang>", "ᒧ",self.wb[i])
+        while m:
+          langspec = m.group(1)
+          self.wb[i] = re.sub(m.group(0), "ᒪ'{}'".format(langspec), self.wb[i], 1)
+          # self.wb[i] = re.sub(m.group(0), "<span LANG=\"{0}\" xml:LANG=\"{0}\">".format(langspec), self.wb[i], 1)
+          m = re.search(r"<lang=[\"']?([^\"'>]+)[\"']?>",self.wb[i])
+        if "lang=" in self.wb[i]:
+          self.fatal("incorrect lang markup: {}".format(self.wb[i]))
+        self.wb[i] = re.sub(r"<\/lang>", "ᒧ",self.wb[i])
+        i += 1
 
       
     # -------------------------------------------------------------------------


### PR DESCRIPTION
This set of changes should fix problem 3  that we discussed earlier, in closed issue 19, where ppgen was detecting and complaining about lang= specifications in HTML literal blocks.

As it turns out, you had already fixed  problem 2, where any book containing the string LANG would have lang instead in the HTML.
