### PR TITLE
Fix for issue with ' character contained in .il alt parameter

### DIFF
--- a/ppgen.py
+++ b/ppgen.py
@@ -3070,6 +3070,7 @@ class Pph(Book):
       alt = ""
       if "alt=" in s:
         s, alt = self.get_id("alt",s)
+        alt = re.sub("'","&#39;",alt) # escape any '
       ia["alt"] = alt
 
       # page number


### PR DESCRIPTION
Hi Roger,

This change fixes the "apostrophes in image alt text" issue reported in the forums by tfkowal.
