### PR TITLE
Fix minor .ma bug

### DIFF
--- a/ppgen.py
+++ b/ppgen.py
@@ -412,7 +412,6 @@ class Book(object):
           self.mau.append(m.group(2))
           self.mal.append(m.group(4))
           del self.wb[i]
-          i -= 1
           continue
 
         m = re.match(r"\.ma ([\"'])(.*?)\1 (.*?)$", self.wb[i])  # only first in quotes
@@ -420,7 +419,6 @@ class Book(object):
           self.mau.append(m.group(2))
           self.mal.append(m.group(3))
           del self.wb[i]
-          i -= 1
           continue
           
         m = re.match(r"\.ma (.*?) ([\"'])(.*?)\2", self.wb[i])  # only second in quotes
@@ -428,7 +426,6 @@ class Book(object):
           self.mau.append(m.group(1))
           self.mal.append(m.group(3))
           del self.wb[i]
-          i -= 1
           continue
 
         m = re.match(r"\.ma (.*?) (.*?)$", self.wb[i])  # neither in quotes
@@ -436,7 +433,6 @@ class Book(object):
           self.mau.append(m.group(1))
           self.mal.append(m.group(2))
           del self.wb[i]
-          i -= 1
           continue
 
       i += 1


### PR DESCRIPTION
Removed unnecessary "i -= 1" statements from the code that
processes the .ma directive. As each section of code deletes
the .ma statement, then uses continue, the loop variable i is
never incremented when the .ma statement is processed, and so
the variable does not need to be decremented.

With the decrement in place, the statement before the .ma is scanned
multiple times. Or, for a .ma happening first in the file, the last
statement in the file is processed unnecessarily when looking at
after i is decremented from 0 to -1 after that first statement is
deleted and we then look at self.wb[-1].
