### PR TITLE
Add missing known_register = True

### DIFF
--- a/ppgen.py
+++ b/ppgen.py
@@ -338,6 +338,7 @@ class Book(object):
         known_register = True
       if registerName == "Illustration": # foreign language translation for "Illustration"
         self.nregs["Illustration"] = self.deQuote(m.group(2), self.cl)
+        known_register = True
       if registerName == "dcs": # drop cap font size
         self.nregs["dcs"] = m.group(2)
         known_register = True


### PR DESCRIPTION
Fixes an issue introduced with pr #44. During the merge a line of code was "borrowed" from the "Illustration" register, this adds it back

``` python
known_register = True
```
