### PR TITLE
Fix issue where .pn statements inside .nf blocks result in leading space miscalculation

### DIFF
--- a/ppgen.py
+++ b/ppgen.py
@@ -3627,11 +3627,11 @@ class Pph(Book):
         # there may be some tags *before* the leading space
         tmp = self.wb[i][:]
         ss = ""
-        m = re.match(r"^<[^>]+>", tmp)
+        m = re.match(r"^<[^>]+>|⑯\w+⑰", tmp)
         while m:
           ss += m.group(0)
-          tmp = re.sub(r"^<[^>]+>", "", tmp)
-          m = re.match(r"^<[^>]+>", tmp)
+          tmp = re.sub(r"^<[^>]+>|⑯\w+⑰", "", tmp)
+          m = re.match(r"^<[^>]+>|⑯\w+⑰", tmp)
         leadsp = len(tmp) - len(tmp.lstrip())
         if cpvs > 0:
           spvs = " style='margin-top:{}em' ".format(cpvs)


### PR DESCRIPTION
Hi Roger,

While working on the index section of my latest PP project, I noticed a minor bug. Within an .nf block, leading spaces are not set properly for lines which follow a .pn statement (HTML output only).

[This file](https://dl.dropboxusercontent.com/u/59728548/test-src.txt) demonstrates the issue (notice how the lines which immediately follow .pn statements are not indented properly)

The code related to this was already accounting for inline style </> markup, this fix checks for page number markup as well.

David
