### PR TITLE
Removed erroneous "i -= 1" while merging page numbers down

### DIFF
--- a/ppgen.py
+++ b/ppgen.py
@@ -3643,7 +3643,7 @@ class Pph(Book):
         m = re.match(r"^<[^>]+>|⑯\w+⑰", tmp)
         while m:
           ss += m.group(0)
-          tmp = re.sub(r"^<[^>]+>|⑯\w+⑰", "", tmp)
+          tmp = re.sub(r"^<[^>]+>|⑯\w+⑰", "", tmp, 1)
           m = re.match(r"^<[^>]+>|⑯\w+⑰", tmp)
         leadsp = len(tmp) - len(tmp.lstrip())
         if cpvs > 0:


### PR DESCRIPTION
Just after a del self.wb[i] when finding two .pn commands in a row
ppgen had
  i -= 1  counteract i += 1 below
  continue
The decrement is unneeded because with the "continue" it never reaches
the increment operation. In practice, the decrement can cause the page
number to actually move up a line into text rather than down as intended.
