### PR TITLE
Catch exception if wrapping fails due to no blanks in line being wrapped

### DIFF
--- a/ppgen.py
+++ b/ppgen.py
@@ -1036,12 +1036,22 @@ class Ppt(Book):
           snip_at = s.rindex(" ", 0, twidth)
         except:
           # could not find a place to wrap
-          snip_at = s.index(" ", twidth) # Plan B
-          self.warn("wide line: {}".format(s))
+          try: # this one might fail, too, so catch exceptions
+            snip_at = s.index(" ", twidth) # Plan B
+          except:
+            snip_at = len(s)
+          if len(t) == 0:
+            self.warn("wide line: {}".format(hold + s)) # include any "hold" characters if wrapping first line
+          else:
+            self.warn("wide line: {}".format(s)) # else just include the current line.
         t.append(s[:snip_at])
-        s = s[snip_at+1:]
+        if snip_at < len(s):
+          s = s[snip_at+1:]
+        else:
+          s = ""
         twidth = mywidth  
-    t.append(s)
+    if len(s) > 0:
+      t.append(s)
 
     for i, line in enumerate(t):
         t[i] = t[i].replace("◠◠", "—") # restore dash


### PR DESCRIPTION
Reported by kdweeks via email. 

Code already had a try/except for splitting between 0 and width, but the splitting in the except clause was unprotected, leading to a Python exception if there were no blanks in the line further to the right, either. Added another try/except to protect that, adjusted one error message for clarity, and made sure that if we can't split the remainder of the line that we don't get an extra blank line added.
