### PR TITLE
Apply pending vertical space (pvs) before HTML .li blocks

### DIFF
--- a/ppgen.py
+++ b/ppgen.py
@@ -3086,7 +3086,11 @@ class Pph(Book):
 
   # .li literal (pass-through)
   def doLit(self):
-    del self.wb[self.cl]  # .li
+    if self.pvs > 0: # handle any pending vertical space before the .li
+      self.wb[self.cl] = "<div style=\"margin-top:{}em;\"></div>".format(self.pvs)
+      self.pvs = 0
+    else:
+      del self.wb[self.cl]  # .li
     while (self.cl < len(self.wb)) and self.wb[self.cl] != ".li-":
       # leave in place
       self.cl += 1


### PR DESCRIPTION
Problem reported in team discussion by tfkowal: http://www.pgdp.net/phpBB2/viewtopic.php?p=999955#999955

This fix applies any current pvs via a standalone <div> prior to handling an HTML .li block.

(Note that Nigel came up with a solution for Tom that does not require the .li block, but it seems reasonable to me that the pvs should apply before the .li block rather than after it.)
