### PR TITLE
Fix for interaction issue between page numbers and html literal blocks

### DIFF
--- a/ppgen.py
+++ b/ppgen.py
@@ -2620,7 +2620,7 @@ class Pph(Book):
           # if we hit the start of a .li, warn the user and put the page number line back in.
           # it can't float into or over the .li, so it will appear wherever it appears
           if self.wb[i].startswith(".li"):
-            self.warn(".li encountered while placing page number")
+            self.warn(".li encountered while placing page number: {}".format(pnum))
             self.wb.insert(i,"⑯{}⑰".format(pnum)) # insert page number before the .li
             i += 2 # bump past new page number line and the .li
             found = True


### PR DESCRIPTION
As tfkowal reported ( http://www.pgdp.net/phpBB2/viewtopic.php?p=1000196#1000196 )
if a .pn command occurs and there is no eligible insertion spot before a .li
then we get HTML that will not validate.

ppgen issues a warning, but then plops the page number info onto the start
of the first line inside the .li block.

The problem tom Tom spotted is that he ended up with a line
reading: &lt;span...> page number info &lt;/span>&lt;table> table info...
and then the ppgen code to detect "naked" page numbers and enclose them in
a div did not work. So he ended up with a naked span, and code
that would not validate.

This fix just leaves the page number just before the .li. It will later
become part of a paragraph comprising only the page number, but at least
the code will validate, and the user has the warning message to alert him
that something may be amiss.
