### PR TITLE
Fix issue where ppgen long line warning sometimes cause a crash

### DIFF
--- a/ppgen.py
+++ b/ppgen.py
@@ -1599,8 +1599,7 @@ class Ppt(Book):
         if longcount == 4:
           self.warn("additional long lines not reported")
         if longcount < 4:
-          m = re.match(r".{0,60}\s", s)
-          self.warn("long line (>{}) beginning:\n  {}....".format(self.linelimitwarning, m.group(0)))
+          self.warn("long line (>{}) beginning:\n  {} ...".format(self.linelimitwarning, s[:60]))
       f1.write( "{:s}\r\n".format(s) )
     f1.close()
 
@@ -1665,8 +1664,7 @@ class Ppt(Book):
         if longcount == 4:
           self.warn("additional long lines not reported")
         if longcount < 4:
-          m = re.match(r".{0,60}\s", s)
-          self.warn("long line (>{}) beginning:\n  {}....".format(self.linelimitwarning, m.group(0)))
+          self.warn("long line (>{}) beginning:\n  {} ...".format(self.linelimitwarning, s[:60]))
       f1.write( "{:s}\r\n".format(s) )
     f1.close()
 


### PR DESCRIPTION
Hi Walt,

I came across this issue today that causes ppgen to crash during processing:

```
[david@bob the-impending-crisis]$ ppgen -i testbug.txt
ppgen 3.46g
creating Latin-1 text file
**warning: wide line: +-------------------+---------------+----------------+-------------+---------------------+
Traceback (most recent call last):
  File "/home/david/pp/tools/ppgen", line 5580, in <module>
    main()
  File "/home/david/pp/tools/ppgen", line 5560, in main
    ppt.run()
  File "/home/david/pp/tools/ppgen", line 2629, in run
    self.saveLat1(self.outfile) # Latin-1
  File "/home/david/pp/tools/ppgen", line 1669, in saveLat1
    self.warn("long line (>{}) beginning:\n  {}....".format(self.linelimitwarning, m.group(0)))
AttributeError: 'NoneType' object has no attribute 'group'
[david@bob the-impending-crisis]$
```

testbug.txt contains one line:
```
+-------------------+---------------+----------------+-------------+---------------------+
```
The problem is the regex two lines above doesn't consider the line above a match (I think because there is no whitespace until after 60 characters). 
```
m = re.match(r".{0,60}\s", s)
```
I believe the intention here was to limit the size of the warning message and break on a word boundry. This patch changes this behavior to simple truncate the line at 60 characters.

-David