### PR TITLE
Standardize malformed directive error handling

### DIFF
--- a/ppgen.py
+++ b/ppgen.py
@@ -1613,16 +1613,18 @@ class Book(object):
       self.crash_w_context("unhandled dot command: {}".format(self.wb[self.cl]), self.cl)
 
   def crash_w_context(self, msg, i, r=5):
-    print("{}\ncontext:".format(self.umap(msg)))
+    sys.stderr.write("\nERROR: {}\ncontext:".format(self.umap(msg)))
     startline = max(0,i-r)
     endline = min(len(self.wb),i+r)
+    sys.stderr.write(" -----")
     for j in range(startline,endline):
       s = self.umap(self.wb[j])
       if j == i:
-        print(">> {}".format(s))
+        sys.stderr.write(">> {}".format(s))
       else:
-        print("   {}".format(s))
-    self.fatal("exiting")
+        sys.stderr.write("   {}".format(s))
+    sys.stderr.write(" -----")
+    exit(1)
 
   # extract content of an optionally quoted string
   # used in .nr

--- a/ppgen.py
+++ b/ppgen.py
@@ -1613,17 +1613,17 @@ class Book(object):
       self.crash_w_context("unhandled dot command: {}".format(self.wb[self.cl]), self.cl)
 
   def crash_w_context(self, msg, i, r=5):
-    sys.stderr.write("\nERROR: {}\ncontext:".format(self.umap(msg)))
+    sys.stderr.write("\nERROR: {}\ncontext:\n".format(self.umap(msg)))
     startline = max(0,i-r)
     endline = min(len(self.wb),i+r)
-    sys.stderr.write(" -----")
+    sys.stderr.write(" -----\n")
     for j in range(startline,endline):
       s = self.umap(self.wb[j])
       if j == i:
-        sys.stderr.write(">> {}".format(s))
+        sys.stderr.write(">> {}\n".format(s))
       else:
-        sys.stderr.write("   {}".format(s))
-    sys.stderr.write(" -----")
+        sys.stderr.write("   {}\n".format(s))
+    sys.stderr.write(" -----\n")
     exit(1)
 
   # extract content of an optionally quoted string

--- a/ppgen.py
+++ b/ppgen.py
@@ -3298,7 +3298,7 @@ class Ppt(Book):
       howmany = int(m.group(1))
       self.eb.append(".RS {}".format(howmany))
     else:
-      self.fatal("malformed space directive: {}".format(self.wb[self.cl]))
+      self.fatal("malformed .sp directive: {}".format(self.wb[self.cl]))
     self.cl += 1
 
   # .fs
@@ -5733,7 +5733,7 @@ class Pph(Book):
       self.pvs = max(int(m.group(1)), self.pvs)  # honor if larger than current pvs
       del self.wb[self.cl]
     else:
-      self.fatal("malformed space directive: {}".format(self.wb[self.cl]))
+      self.fatal("malformed .sp directive: {}".format(self.wb[self.cl]))
 
   # .fs
   # change font size for following paragraphs
@@ -5754,7 +5754,7 @@ class Pph(Book):
       self.fsz = m.group(1) + "em"
       self.wb[self.cl] = ""
     if ".fs" in self.wb[self.cl]:
-      self.warn("font-size directive error: {}".format(self.wb[self.cl]))
+      self.fatal("malformed .fs directive: {}".format(self.wb[self.cl]))
     del self.wb[self.cl]
 
   # .il illustrations
@@ -6701,7 +6701,7 @@ class Pph(Book):
         d_height = m.group(3)
         d_adj = m.group(4)
       else:
-        self.crash_w_context("malformed drop image directive", self.cl)
+        self.crash_w_context("malformed .di directive", self.cl)
 
     self.warn("CSS3 drop-cap. Please note in upload.")
     self.css.addcss("[1920] img.drop-capi { float:left;margin:0 0.5em 0 0;position:relative;z-index:1; }")
@@ -6888,7 +6888,7 @@ class Pph(Book):
         self.cl += 1
         nlines -= 1
     else:
-      self.warn("malformed .rj directive: {}".format(self.wb[i]))
+      self.fatal("malformed .rj directive: {}".format(self.wb[i]))
 
   def doSidenote(self):
     # handle sidenotes outside paragraphs, sidenotes inside paragraphs are done in <sn>-style markup

--- a/ppgen.py
+++ b/ppgen.py
@@ -1644,7 +1644,7 @@ class Book(object):
   def doNr(self):
     m = re.match(r"\.nr (.+?) (.+)", self.wb[self.cl])
     if not m:
-      self.crash_w_context("malformed .nr command: {}".format(self.wb[self.cl]), self.cl)
+      self.crash_w_context("malformed .nr directive", self.cl)
     else:
       registerName = m.group(1)
       registerValue = m.group(2)
@@ -2311,7 +2311,7 @@ class Book(object):
           self.wb[i] = ".nf c"
           self.wb.insert(i+nlines+1, ".nf-")
         else:
-          self.fatal("malformed .ce directive: {}".format(self.wb[i]))
+          self.crash_w_context("malformed .ce directive", self.cl)
       i += 1
 
     # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2394,7 +2394,7 @@ class Book(object):
           else:
             image_type = temp
         else:
-          self.crash_w_context("malformed .bn command",i)
+          self.crash_w_context("malformed .bn directive", self.cl)
       i += 1
 
     # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3300,7 +3300,7 @@ class Ppt(Book):
       howmany = int(m.group(1))
       self.eb.append(".RS {}".format(howmany))
     else:
-      self.fatal("malformed .sp directive: {}".format(self.wb[self.cl]))
+      self.crash_w_context("malformed .sp directive", self.cl)
     self.cl += 1
 
   # .fs
@@ -3436,7 +3436,7 @@ class Ppt(Book):
     if handled:
       self.cl += 1
     else:
-      self.fatal("malformed .in command: \"{}\"".format(self.wb[self.cl]))
+      self.crash_w_context("malformed .in directive", self.cl)
 
   # .ll line length
   def doLl(self):
@@ -3476,7 +3476,7 @@ class Ppt(Book):
       return
 
     # if here, has not been handled
-    self.fatal("malformed .ll command: \"{}\"".format(self.wb[self.cl]))
+    self.crash_w_context("malformed .ll directive", self.cl)
 
   # .ti temporary indent
   def doTi(self):
@@ -4033,7 +4033,7 @@ class Ppt(Book):
         nlines -= 1
       self.eb.append(".RS 1")
     else:
-      self.fatal("malformed .rj directive: {}".format(self.wb[self.cl]))
+      self.crash_w_context("malformed .rj directive", self.cl)
 
   # .de CSS definition
   # ignore the directive in text
@@ -4055,7 +4055,7 @@ class Ppt(Book):
       self.eb.append(".RS 1") # request at least one space in text after sidenote
       self.cl += 1
     else:
-      self.fatal("malformed .sn directive: {}".format(self.wb[self.cl])) # should never hit this as preprocesscommon() checked it
+      self.crash_w_context("malformed .sn directive", self.cl) # should never hit this as preprocesscommon() checked it
 
   def doPara(self):
     t = []
@@ -5735,7 +5735,7 @@ class Pph(Book):
       self.pvs = max(int(m.group(1)), self.pvs)  # honor if larger than current pvs
       del self.wb[self.cl]
     else:
-      self.fatal("malformed .sp directive: {}".format(self.wb[self.cl]))
+      self.crash_w_context("malformed .sp directive", self.cl)
 
   # .fs
   # change font size for following paragraphs
@@ -5756,7 +5756,7 @@ class Pph(Book):
       self.fsz = m.group(1) + "em"
       self.wb[self.cl] = ""
     if ".fs" in self.wb[self.cl]:
-      self.fatal("malformed .fs directive: {}".format(self.wb[self.cl]))
+      self.crash_w_context("malformed .fs directive", self.cl)
     del self.wb[self.cl]
 
   # .il illustrations
@@ -6082,7 +6082,7 @@ class Pph(Book):
       return
 
     # should not get here
-    self.fatal("malformed .in command: \"{}\"".format(self.wb[self.cl]))
+    self.crash_w_context("malformed .in directive", self.cl)
 
   # .ll line length
   def doLl(self):
@@ -6122,7 +6122,7 @@ class Pph(Book):
       return
 
     # should not get here
-    self.fatal("malformed .ll directive: {}".format(self.wb[self.cl]))
+    self.crash_w_context("malformed .ll directive", self.cl)
 
   # .ti temporary indent
   def doTi(self):
@@ -6890,7 +6890,7 @@ class Pph(Book):
         self.cl += 1
         nlines -= 1
     else:
-      self.fatal("malformed .rj directive: {}".format(self.wb[i]))
+      self.crash_w_context("malformed .rj directive", self.cl)
 
   def doSidenote(self):
     # handle sidenotes outside paragraphs, sidenotes inside paragraphs are done in <sn>-style markup
@@ -6904,7 +6904,7 @@ class Pph(Book):
         self.wb[self.cl] = "<div class='sidenote'>{}</div>".format(m.group(1))
       self.cl += 1
     else:
-      self.fatal("malformed .sn directive: {}".format(self.wb[self.cl]))
+      self.crash_w_context("malformed .sn directive", self.cl)
 
   def doPara(self):
     s = self.fetchStyle() # style line with current parameters


### PR DESCRIPTION
Hi Walt,

In a recent project I misused the .fs dot command by trying to close it with a .fs- (this command has no closer). There was a warning generated for a malformed .fs directive, but I didn't notice it (output is pretty chatty). The bad .fs directive caused the font change to be more widespread than I wanted and I didn't notice the issue in the HTML right away. 

This patch makes all malformed directive type errors fatal (all but .fs and .sp already were) and standardizes the way these errors are reported.

I also changed the output of crash_w_context() a little to make it more readable.