### PR TITLE
Skip over dotfiles when reviewing image extensions

### DIFF
--- a/ppgen.py
+++ b/ppgen.py
@@ -12515,6 +12515,8 @@ class Pph(Book):
 
       if DirectoryOK:
         for s in filelist:
+          if s[0] == ".":
+            continue
           found = False
           for t in filetypes:
             if s.endswith(t):


### PR DESCRIPTION
While examining image file extensions, skip over any files whose name begins with "." which on Linux & macOS are meant to be ignored.

On macOS specifically the Finder creates metadata files called ".DS_Store", leading me to submit this change, but many other dotfiles might exist that should also be ignored.

Edge case: someone could, for some reason, go against best practice and name their images using a leading dot.