### PR TITLE
Fix exception

### DIFF
--- a/ppgen.py
+++ b/ppgen.py
@@ -6012,8 +6012,8 @@ class Ppt(Book):
         while m:
           bnInLine = True
           t = " 'Pg{}' => ['offset' => '{}.{}', 'label' => '', 'style' => '', 'action' => '', 'base' => ''],".format(m.group(2),i+1,len(m.group(1)))  # format a line in the .bn array (GG wants a 1-based count)
-          t = re.sub("[","{",t,1)
-          t = re.sub("]","}",t,1)
+          t = re.sub("\\[","{",t,1)
+          t = re.sub("\\]","}",t,1)
           self.bb.append(t)
           if self.ppqt2:
             ccount += len(m.group(1)) - offset1 # count characters we haven't counted so far

--- a/ppgen.py
+++ b/ppgen.py
@@ -11139,8 +11139,8 @@ class Pph(Book):
         while m:
           bnInLine = True
           t = " 'Pg{}' => ['offset' => '{}.{}', 'label' => '', 'style' => '', 'action' => '', 'base' => ''],".format(m.group(2),i+1,len(m.group(1)))  # format a line in the .bn array (GG expects 1-based line number)
-          t = re.sub("[","{",t,1)
-          t = re.sub("]","}",t,1)
+          t = re.sub("\\[","{",t,1)
+          t = re.sub("\\]","}",t,1)
           self.bb.append(t)
           if self.ppqt2:
             ccount += len(m.group(1)) - offset1 # count characters we haven't counted so far


### PR DESCRIPTION
Previously, processing .bn commands would result in an exception: `re.error: unterminated character set at position 0`

Full exception:

```
/Users/dan/.pyenv/shims/python3 /Users/dan/repos/dp/ppgen/ppgen.py -i pascal-src.txt -o u
ppgen 3.57f
**Detected encoding: utf_8
creating UTF-8 text file
**warning: inserting leading space in wide .nf c (or .ce)
Traceback (most recent call last):
  File "/Users/dan/repos/dp/ppgen/ppgen.py", line 12744, in <module>
    main()
  File "/Users/dan/repos/dp/ppgen/ppgen.py", line 12725, in main
    ppt.run()
  File "/Users/dan/repos/dp/ppgen/ppgen.py", line 8044, in run
    self.postprocess()
  File "/Users/dan/repos/dp/ppgen/ppgen.py", line 6015, in postprocess
    t = re.sub("[","{",t,1)
        ^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.3/Frameworks/Python.framework/Versions/3.12/lib/python3.12/re/__init__.py", line 186, in sub
    return _compile(pattern, flags).sub(repl, string, count)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.3/Frameworks/Python.framework/Versions/3.12/lib/python3.12/re/__init__.py", line 307, in _compile
    p = _compiler.compile(pattern, flags)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.3/Frameworks/Python.framework/Versions/3.12/lib/python3.12/re/_compiler.py", line 745, in compile
    p = _parser.parse(p, flags)
        ^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.3/Frameworks/Python.framework/Versions/3.12/lib/python3.12/re/_parser.py", line 979, in parse
    p = _parse_sub(source, state, flags & SRE_FLAG_VERBOSE, 0)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.3/Frameworks/Python.framework/Versions/3.12/lib/python3.12/re/_parser.py", line 460, in _parse_sub
    itemsappend(_parse(source, state, verbose, nested + 1,
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.3/Frameworks/Python.framework/Versions/3.12/lib/python3.12/re/_parser.py", line 568, in _parse
    raise source.error("unterminated character set",
re.error: unterminated character set at position 0
make: *** [pascal] Error 1
```