### PR TITLE
Correct pngspath in Guiguts .bin files

### DIFF
--- a/ppgen.py
+++ b/ppgen.py
@@ -1983,7 +1983,7 @@ class Book(object):
       temp = os.path.dirname(temp)
       temp = os.path.join(temp, "pngs")
       bb.append(");")  # finish building GG .bin file
-      bb.append(r"$::pngspath = '{}\\';".format(os.path.join(os.path.realpath(self.srcfile),"pngs")))
+      bb.append(r"$::pngspath = '{}';".format(os.path.join(os.path.dirname(os.path.realpath(self.srcfile)),"pngs","")))
       bb.append("1;")
       binfn = self.srcfile + ".bin"
       f1 = codecs.open(binfn, "w", "ISO-8859-1")
@@ -6029,7 +6029,7 @@ class Ppt(Book):
           i += 1
       self.bb.append(");")  # finish building GG .bin file
       #self.bb.append("$::pngspath = '{}\\';".format(os.path.join(os.path.dirname(self.srcfile),"pngs")))
-      self.bb.append(r"$::pngspath = '{}\\';".format(os.path.join(os.path.realpath(self.srcfile),"pngs")))
+      self.bb.append(r"$::pngspath = '{}';".format(os.path.join(os.path.dirname(os.path.realpath(self.srcfile)),"pngs","")))
       self.bb.append("1;")
 
   # -------------------------------------------------------------------------------------
@@ -11163,7 +11163,7 @@ class Pph(Book):
           i += 1
       self.bb.append(");")
       #self.bb.append("$::pngspath = '{}\\';".format(os.path.join(os.path.dirname(self.srcfile),"pngs")))
-      self.bb.append(r"$::pngspath = '{}\\';".format(os.path.join(os.path.realpath(self.srcfile),"pngs")))
+      self.bb.append(r"$::pngspath = '{}';".format(os.path.join(os.path.dirname(os.path.realpath(self.srcfile)),"pngs","")))
       self.bb.append("1;")
 
 


### PR DESCRIPTION
Corrects output (as compared to sample in issue description):

```
❯ grep pngspath *.bin                                                                    
eugenics-src.txt.bin:$::pngspath = '/Users/dan/repos/dp/ppgen/pngs/';
eugenics-utf8.txt.bin:$::pngspath = '/Users/dan/repos/dp/ppgen/pngs/';
eugenics.html.bin:$::pngspath = '/Users/dan/repos/dp/ppgen/pngs/';
```

Fixes #102