### PR TITLE
Add "viewport" meta tag per current HTML5 guidelines

### DIFF
--- a/ppgen.py
+++ b/ppgen.py
@@ -9059,6 +9059,7 @@ class Pph(Book):
     t.append("<!DOCTYPE html>")
     t.append("<html lang=\"" + self.nregs["lang"] + "\">") # include base language in header RT removed deprecated xmlns and xml declarations
     t.append("  <head>")
+    t.append("    <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">")
 
     if self.encoding == "utf_8":
       #t.append("    <meta http-equiv=\"Content-Type\" content=\"text/html;charset=UTF-8\">")


### PR DESCRIPTION
# Summary
DP's [HTML5 header guidance][1] was recently changed to include this tag:

[1]: https://www.pgdp.net/wiki/DP_Official_Documentation:PP_and_PPV/Post-processing_HTML5#Header_for_HTML5

```html
<meta name="viewport" content="width=device-width, initial-scale=1">
```

This PR adds it to the header in ppgen's output.

Additional note: Guiguts 2 recently added this tag to the default HTML header.

# Testing
I ran this code on a few of my own projects. Aside from an outlier (tables), it greatly improved the output on mobile. By default on mobile, the text is tiny and difficult to read without adjusting to zoom in. (This issue has been discussed quite a bit on Slack already, which led to the change in guidelines.)

# Screenshots

These screenshots were all taken with the font size in the browser set to 100%. I produced them with iPhone Simulator on macOS.

## pascal1
<img width="324" height="640" alt="pascal1-before" src="https://github.com/user-attachments/assets/9ecdd1b0-357f-4113-817f-143a7fc44575" /><img width="337" height="640" alt="pascal1-after" src="https://github.com/user-attachments/assets/243dc55f-42de-4faf-8a48-39b47169b9c5" />

## pascal2
<img width="337" height="640" alt="pascal2-before" src="https://github.com/user-attachments/assets/55335c25-f53d-42e2-a5d2-49c5a95d4bf0" /><img width="337" height="640" alt="pascal2-after" src="https://github.com/user-attachments/assets/bc063541-5dc9-4f0a-ab64-c62fca35e050" />

## pascal3
<img width="337" height="640" alt="pascal3-before" src="https://github.com/user-attachments/assets/75027e19-e9b8-46e6-847e-82734fe5aad8" /><img width="324" height="640" alt="pascal3-after" src="https://github.com/user-attachments/assets/7d56c6f0-13e5-4fe3-a129-3d510f8c1ef8" />

## vaxfacts

As I mentioned earlier, tables were an outlier. I didn't attempt to decipher how table CSS is calculated, so it's possible this could be improved. However, the tables render fine. You just need to scroll horizontally to see the entire table. To me, that's acceptable, but you can judge whether this is an issue.

<img width="337" height="640" alt="vaxfacts-before" src="https://github.com/user-attachments/assets/129ceca5-1669-4250-8f68-57684b4bebbc" /><img width="337" height="640" alt="vaxfacts-after" src="https://github.com/user-attachments/assets/bf2e6bbd-4530-46fb-9c1f-80b8c7f2095c" />
