### PR TITLE
Todo noissue

### DIFF
--- a/ppgen.py
+++ b/ppgen.py
@@ -73,8 +73,6 @@ VERSION="3.57g" + with_regex   # 24-Dec-2025
 #  Enh: Skip over dotfiles when reviewing image extensions
 #  Enh: Add "viewport" meta tag per current HTML5 guidelines
 
-###  Todo Bug: In HTML, a .sp placed before a .il does not take effect until the next text after the illustration/caption.
-
 NOW = strftime("%Y-%m-%d %H:%M:%S", gmtime()) + " GMT"
 
 

--- a/ppgen.py
+++ b/ppgen.py
@@ -9835,11 +9835,11 @@ class Pph(Book):
     # create replacement stanza for illustration
     u = []
 
-    #if self.pvs > 0: # pending vertical space?
-    #  mtop = " style='margin-top: {}em; '".format(self.pvs)
-    #  self.pvs=0
-    #else:
-    mtop = "" # prepare for experimental version that applies pvs to illos
+    if self.pvs > 0: # pending vertical space?
+      mtop = " style='margin-top: {}em; '".format(self.pvs)
+      self.pvs=0
+    else:
+      mtop = ""
 
     if ia["align"] == "c":  # with fix for missing id= problem
       u.append("<div {}{} class='figcenter {}'>".format(ia["id"], mtop, idn))


### PR DESCRIPTION
# Enable pending vertical space for illustrations

Illustrations (.il blocks) now honor pending vertical space set by .sp directives. When vertical space is pending before an illustration, it will be applied as a margin-top style on the illustration's container div. Previously, this feature was disabled (the code was commented out). This change enables it by uncommenting the logic that:

- Checks if pending vertical space exists (pvs > 0)
- Applies it as an inline margin-top style to the illustration div
- Resets the pending space counter to 0

This allows PPers to control vertical spacing before illustrations using .sp directives, giving them better control over layout in HTML output.