### PR TITLE
double spacing fix

### DIFF
--- a/ppgen.py
+++ b/ppgen.py
@@ -1909,7 +1909,7 @@ class Book(object):
 
   def cvglist(self):
     if self.listcvg:
-      f1 = open("ppgen-cvglist.txt", "w", encoding="UTF-8")
+      f1 = open("ppgen-cvglist.txt", "w", encoding="UTF-8", newline='')
       f1.write("\r\n\r\nppgen {}\r\n".format(VERSION))
       f1.write("\r\nBuilt-in Greek Characters:\r\n")
       f1.write("User enters:  ppgen generates:\r\n\r\n")
@@ -1932,7 +1932,7 @@ class Book(object):
   # Create special output file after .gk or .cv if requested, and quit
   def cvgbailout(self):
     bailfn = re.sub("-src", "", self.srcfile.split('.')[0]) + "-cvgout-utf8.txt"
-    f1 = open(bailfn, "w", encoding="UTF-8")
+    f1 = open(bailfn, "w", encoding="UTF-8", newline='')
     for index,t in enumerate(self.wb):
       # unprotect temporarily protected characters from Greek strings
       t = t.replace("⑩", r"\|") # restore temporarily protected \| and \(space)
@@ -1967,7 +1967,7 @@ class Book(object):
       self.ppqt.append('  ]')
       self.ppqt.append('}')
       ppqtfn = fn + ".ppqt"
-      f1 = open(ppqtfn, "w", encoding="ISO-8859-1")
+      f1 = open(ppqtfn, "w", encoding="ISO-8859-1", newline='')
       for index,t in enumerate(self.ppqt):
         f1.write("{:s}\r\n".format(t))
       f1.close()
@@ -2008,7 +2008,7 @@ class Book(object):
       bb.append(r"$::pngspath = '{}';".format(os.path.join(os.path.dirname(os.path.realpath(self.srcfile)),"pngs","")))
       bb.append("1;")
       binfn = self.srcfile + ".bin"
-      f1 = open(binfn, "w", encoding="ISO-8859-1")
+      f1 = open(binfn, "w", encoding="ISO-8859-1", newline='')
       for index,t in enumerate(bb):
         f1.write("{:s}\r\n".format(t))
       f1.close()
@@ -5072,7 +5072,7 @@ class Ppt(Book):
       encoding = "UTF-8"
     else:
       encoding = "ISO-8859-1"
-    f1 = open("bailout.txt", "w", encoding=encoding)
+    f1 = open("bailout.txt", "w", encoding=encoding, newline='')
     for index,t in enumerate(buffer):
       f1.write( "{:s}\r\n".format(t.rstrip()) )
     f1.close()
@@ -6070,7 +6070,7 @@ class Ppt(Book):
     longcount = 0
     while (len(self.eb) > 0) and not self.eb[-1]:
       self.eb.pop()
-    f1 = open(fn, "w", encoding="utf-8")
+    f1 = open(fn, "w", encoding="utf-8", newline='')
     for index,t in enumerate(self.eb):
       s = t.rstrip()
       if self.truelen(s) > self.linelimitwarning:
@@ -6086,7 +6086,7 @@ class Ppt(Book):
     if self.bnPresent:
       fnb = fn + ".bin"
       fnj = fn + ".json"
-      f1 = open(fnb, "w", encoding="ISO-8859-1")
+      f1 = open(fnb, "w", encoding="ISO-8859-1", newline='')
       for index,t in enumerate(self.bb):
         f1.write("{:s}\r\n".format(t))
       f1.close()
@@ -6144,7 +6144,7 @@ class Ppt(Book):
     # write Latin-1 file (text output, Latin-1)
     # note: using open allows specific line terminators.
     # using .open would write platform-specific line terminators.
-    f1 = open(fn, "w", encoding="ISO-8859-1")
+    f1 = open(fn, "w", encoding="ISO-8859-1", newline='')
     longcount = 0
     for index,t in enumerate(self.eb):
       s = t.rstrip()
@@ -6160,7 +6160,7 @@ class Ppt(Book):
     # save GG .bin file if needed
     if self.bnPresent:
       fnb = fn + ".bin"
-      f1 = open(fnb, "w", encoding="ISO-8859-1")
+      f1 = open(fnb, "w", encoding="ISO-8859-1", newline='')
       for index,t in enumerate(self.bb):
         f1.write("{:s}\r\n".format(t))
       f1.close()
@@ -8196,7 +8196,7 @@ class Pph(Book):
 
   # bailout after saving working buffer in bailout.txt
   def bailout(self, buffer):
-    f1 = open("bailout.txt", "w", encoding='utf-8')
+    f1 = open("bailout.txt", "w", encoding='utf-8', newline='')
     for index,t in enumerate(buffer):
       f1.write( "{:s}\r\n".format(t.rstrip()) )
     f1.close()
@@ -9049,7 +9049,7 @@ class Pph(Book):
   # -------------------------------------------------------------------------------------
   # save buffer to specified dstfile (HTML output)
   def saveFile(self, fn):
-    f1 = open(fn, "w", encoding=self.encoding)
+    f1 = open(fn, "w", encoding=self.encoding, newline='')
     for index,t in enumerate(self.wb):
       try:
         f1.write( "{:s}\r\n".format(t))
@@ -9062,7 +9062,7 @@ class Pph(Book):
     if self.bnPresent:
       fnb = fn + ".bin"
       fnj = fn + ".json"
-      f1 = open(fnb, "w", encoding="ISO-8859-1")
+      f1 = open(fnb, "w", encoding="ISO-8859-1", newline='')
       for index,t in enumerate(self.bb):
         f1.write("{:s}\r\n".format(t))
       f1.close()


### PR DESCRIPTION
Fix file line endings on Windows by adding newline='' parameter

Add newline='' to 12 file open() calls that write explicit \r\n line 
endings. Without this parameter, Python on Windows converts \n to \r\n, 
causing the explicit \r\n to become \r\r\n (double line endings).

Affected files: cvglist, bailout, .ppqt, .bin, and output files across 
saveFileU(), saveLat1(), and saveFile() functions.
