### PR TITLE
Add meta tag 'format-detection'

### DIFF
--- a/ppgen.py
+++ b/ppgen.py
@@ -9032,6 +9032,7 @@ class Pph(Book):
     t.append("    \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\">")
     t.append("<html xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"" + self.nregs["lang"] + "\" lang=\"" + self.nregs["lang"] + "\">") # include base language in header
     t.append("  <head>")
+    t.append("    <meta name=\"format-detection\" content=\"telephone=no,date=no,address=no,email=no,url=no\">")
 
     if self.encoding == "utf_8":
       t.append("    <meta http-equiv=\"Content-Type\" content=\"text/html;charset=UTF-8\" />")


### PR DESCRIPTION
Mostly (but not entirely) on mobile, this tag tells the browser to turn off data detectors, such as converting phone numbers (or random integers that could possibly be phone numbers, but aren't) into clickable links. Dates are another thing PG books might contain that these detectors will try to pick up to let users add calendar entries.

This PR was inspired by a book I ran containing U.S. patent numbers that my phone mistakenly identified as phone numbers and dutifully converted to links.

As with any meta tag, a browser not knowing what to do with it will simply ignore it. This passes Nu HTML5 validation as well as ebookmaker.

Guiguts has already added this tag (see https://github.com/DistributedProofreaders/guiguts-py/pull/1696)